### PR TITLE
Alternativa packages for Ubuntu 18.04 compilation

### DIFF
--- a/docs/developer/compilation.md
+++ b/docs/developer/compilation.md
@@ -13,6 +13,11 @@
        libspeex-dev libspeexdsp-dev libxslt1-dev libcurl4-openssl-dev \
        libopencv-dev tcl8.5 libmicrohttpd-dev
 ```
+In Ubuntu 18.04 there's no libqtmultimediakit1 and qtmobility-dev packages available. In order to compile in Ubuntu 18.04 you need to install these extra/alternative packages:
+```bash
+   sudo apt-get install libqt5x11extras5-dev qtmultimedia5-dev qttools5-devs
+```
+
 #### openSUSE
 ```bash
    sudo zypper install gcc-c++ libqt4-devel libgnome-keyring-devel \


### PR DESCRIPTION
As it was documented, compilation resulted in error on Ubuntu 18.04 because of package dependencies. These adds the needed packages installation.