### PR TITLE
Enable clickable link

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,1 +1,1 @@
-See https://retroshare.cc/downloads.html
+See <https://retroshare.cc/downloads.html>


### PR DESCRIPTION
Only using GitHub flavoured markdown ("GFM") enables auto HTML link detection. Otherwise, the link must be enclosed in `<...>`.