### PR TITLE
Fix repo link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://retroshare.readthedocs.io
 site_description: RetroShare User Guide
 site_author: RetroShare Community
 
-repo_url: https://github.com/retroshare/documentation.git
+repo_url: https://github.com/retroshare/documentation
 
 site_favicon: favicon.ico
 


### PR DESCRIPTION
When clicking to "Edit on GitHub", a wrong link is generated:

https://github.com/retroshare/documentation.git/edit/master/docs/user-guide/installation.md

With this fix, the correct link is generated:

https://github.com/RetroShare/documentation/edit/master/docs/user-guide/installation.md

See also https://www.mkdocs.org/user-guide/configuration/ --> "repo_url":

> When set, provides a link to your repository (GitHub, Bitbucket, GitLab, ...) on each page.\
> `repo_url: https://github.com/example/repository/`
